### PR TITLE
chore(pre-align): align heading structure with ko

### DIFF
--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -529,6 +529,42 @@ In the **NAT** (Network Address Translation) tab, select and connect a dedicated
  
  <br>
 
+## Mirroring
+
+<!-- TODO: translate body -->
+
+### Mirroring rule
+
+<!-- TODO: translate body -->
+
+### Add
+
+<!-- TODO: translate body -->
+
+### Modify
+
+<!-- TODO: translate body -->
+
+### Delete
+
+<!-- TODO: translate body -->
+
+### Filter group
+
+<!-- TODO: translate body -->
+
+### Add
+
+<!-- TODO: translate body -->
+
+### Modify
+
+<!-- TODO: translate body -->
+
+### Delete
+
+<!-- TODO: translate body -->
+
 ## VPN
 
 The **VPN** tab enables secure, private communication over an encrypted tunnel between sites.


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api` (Anthropic SDK) |
| Model | `claude-sonnet-4-20250514` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `master` |
| Scope | 3 doc(s); 1 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/4/ |
| Generated | 2026-06-09T00:06:26 |

## Changes

| File | level fixed | inserted | id fixed | extra flagged | extra removed | verify |
| --- | --: | --: | --: | --: | --: | :--: |
| `en/console-guide.md` | 0 | 9 | 0 | 0 | 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Network-Firewall`