### PR TITLE
chore(pre-align): align heading structure with ko

### DIFF
--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -529,6 +529,42 @@ In the **NAT** (Network Address Translation) tab, select and connect a dedicated
  
  <br>
 
+## Mirroring
+
+<!-- TODO: translate body -->
+
+### Mirroring rule
+
+<!-- TODO: translate body -->
+
+### Add
+
+<!-- TODO: translate body -->
+
+### Modify
+
+<!-- TODO: translate body -->
+
+### Delete
+
+<!-- TODO: translate body -->
+
+### Filter group
+
+<!-- TODO: translate body -->
+
+### Add
+
+<!-- TODO: translate body -->
+
+### Modify
+
+<!-- TODO: translate body -->
+
+### Delete
+
+<!-- TODO: translate body -->
+
 ## VPN
 
 The **VPN** tab enables secure, private communication over an encrypted tunnel between sites.


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Existing body text is never modified.** The heading match only sees outlines and edits heading lines. Missing sections, however, get a **machine-translated body** (0 section[s] this run) — review the translated wording before merging.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-20250514` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `master` |
| Scope | 3 doc(s); 1 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://testlab.cloud.toastoven.net:8080/job/user-guide-agent/job/align-heading/job/260521/31/ |
| Generated | 2026-06-09T08:15:52 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`master`): [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-Firewall%2Ftree%2Fmaster&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://10.150.13.33:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNetwork-Firewall%2Fpull%2F102&source=ko&langs=en%2Cja)

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | :--: |
| `en/console-guide.md` | 0 | 9 | 0 | 0 | 0 | 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Network-Firewall`